### PR TITLE
Fix: support InterestBearingConfig extension

### DIFF
--- a/programs/amm/src/util/token.rs
+++ b/programs/amm/src/util/token.rs
@@ -250,6 +250,7 @@ pub fn is_supported_mint(mint_account: &InterfaceAccount<Mint>) -> Result<bool> 
         if e != ExtensionType::TransferFeeConfig
             && e != ExtensionType::MetadataPointer
             && e != ExtensionType::TokenMetadata
+            && e != ExtensionType::InterestBearingConfig
         {
             return Ok(false);
         }


### PR DESCRIPTION
Because the accrued interest is simply a visual UI conversion, but the underlying token quantity remains unchanged.
This extension has no effect on the contract.