### PR TITLE
fix:add transfer fee check for reset pool token2022 reward

### DIFF
--- a/programs/amm/src/instructions/increase_liquidity.rs
+++ b/programs/amm/src/instructions/increase_liquidity.rs
@@ -141,6 +141,7 @@ pub fn increase_liquidity<'a, 'b, 'c: 'info, 'info>(
     amount_1_max: u64,
     base_flag: Option<bool>,
 ) -> Result<()> {
+    require_gt!(liquidity, 0);
     let mut liquidity = liquidity;
     let pool_state = &mut pool_state_loader.load_mut()?;
     if !pool_state.get_status_by_bit(PoolStatusBitIndex::OpenPositionOrIncreaseLiquidity) {

--- a/programs/amm/src/instructions/increase_liquidity.rs
+++ b/programs/amm/src/instructions/increase_liquidity.rs
@@ -141,7 +141,6 @@ pub fn increase_liquidity<'a, 'b, 'c: 'info, 'info>(
     amount_1_max: u64,
     base_flag: Option<bool>,
 ) -> Result<()> {
-    require_gt!(liquidity, 0);
     let mut liquidity = liquidity;
     let pool_state = &mut pool_state_loader.load_mut()?;
     if !pool_state.get_status_by_bit(PoolStatusBitIndex::OpenPositionOrIncreaseLiquidity) {

--- a/programs/amm/src/util/token.rs
+++ b/programs/amm/src/util/token.rs
@@ -26,7 +26,7 @@ const MINT_WHITELIST: [&'static str; 6] = [
     "Crn4x1Y2HUKko7ox2EZMT6N2t2ZyH7eKtwkBGVnhEq1g",
     "FrBfWJ4qE5sCzKm3k3JaAtqZcXUh4LvJygDeketsrsH4",
     "2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo",
-    "DAUDev5e4Go36o7d9LEXSKD4YeQ3tHri9oPTXWxh5YqU",
+    "DAUcJBg4jSpVoEzASxYzdqHMUN8vuTpQyG2TvDcCHfZg",
     "AUSD1jCcCyPLybk1YnvPWsHQSrZ46dxwoMniN4N2UEB9",
 ];
 


### PR DESCRIPTION
1. Add transfer fee check when reset pool token2022 reward  for set_reward_param instruction
2. Modify the update logic of protocol position, so that the decrease instruction can be triggered even if the liquidity of the position is zero