### PR TITLE
chore(gitignore): add .idea to ignore IntelliJ files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 
 .anchor
 .DS_Store
+.idea
 target
 KeyPairs
 *.json


### PR DESCRIPTION
Added .idea directory to .gitignore to prevent RustRover IDEA's configuration files (e.g., workspace settings, run configurations) from being committed. This ensures a cleaner repository and avoids conflicts between developers using different IDE settings.