### PR TITLE
feat: Fix swap_router_base_in

### DIFF
--- a/programs/amm/src/instructions/swap_v2.rs
+++ b/programs/amm/src/instructions/swap_v2.rs
@@ -67,7 +67,7 @@ pub struct SwapSingleV2<'info> {
     )]
     pub output_vault_mint: Box<InterfaceAccount<'info, Mint>>,
     // remaining accounts
-    // tickarray_bitmap_extension: must add account if need regardless the sequence
+    // tickarray_bitmap_extension: must add account if need
     // tick_array_account_1
     // tick_array_account_2
     // tick_array_account_...
@@ -136,6 +136,9 @@ pub fn exact_internal_v2<'c: 'info, 'info>(
                         .deref()),
                 );
                 continue;
+            }
+            if account_info.data_len() != TickArrayState::LEN {
+                break;
             }
             tick_array_states.push_back(AccountLoad::load_data_mut(account_info)?);
         }


### PR DESCRIPTION
Currently the `swap_router_base_in` instruction is broken if the swap is a multi-hop swap

For example, if an user tries to swap token X -> Y -> Z with X -> Y through pool A and Y -> Z through pool B, based on the code of instruction `swap_router_base_in`: https://github.com/raydium-io/raydium-clmm/blob/master/programs/amm/src/instructions/swap_router_base_in.rs#L42 we need to supply 2 sets of remaining accounts corresponding to pool A and B as shown below
```javascript
const poolStates = [poolA, poolB]
const remainingAccounts = poolStates.flatMap((poolState, idx) => [
  // amm config
  {
    pubkey: poolState.ammConfig,
    isWritable: true,
    isSigner: false,
  },
  // pool state
  {
    pubkey: routePlan[idx].poolId,
    isWritable: true,
    isSigner: false,
  },
  // output token account
  {
    pubkey: getAssociatedTokenAddressSync(
      routePlan[idx].outputMint,
      wallet.publicKey,
      false,
      tokenPrograms.get(routePlan[idx].outputMint.toBase58())!,
    ),
    isWritable: true,
    isSigner: false,
  },
  // input vault
  {
    pubkey: poolState.tokenMint0.equals(routePlan[idx].inputMint)
      ? poolState.tokenVault0
      : poolState.tokenVault1,
    isWritable: true,
    isSigner: false,
  },
  // output vault
  {
    pubkey: poolState.tokenMint0.equals(routePlan[idx].outputMint)
      ? poolState.tokenVault0
      : poolState.tokenVault1,
    isWritable: true,
    isSigner: false,
  },
  // output token mint
  {
    pubkey: routePlan[idx].outputMint,
    isWritable: true,
    isSigner: false,
  },
  // observation state
  {
    pubkey: poolState.observationKey,
    isWritable: true,
    isSigner: false,
  },
  // tick bitmap extension
  {
    pubkey: tickArrayBitmapExtensionAddresses[idx],
    isWritable: true,
    isSigner: false,
  },
  // tick array states
  ...poolTickArrayStates[idx].map((e) => ({
    pubkey: e.publicKey,
    isWritable: true,
    isSigner: false,
  })),
]);
```

However, this will cause `exact_internal_v2` to fail here: https://github.com/raydium-io/raydium-clmm/blob/master/programs/amm/src/instructions/swap_v2.rs#L140
Suppose the remaining accounts for pool A is called set A and for B is set B, when the loop iterate to the first account of set B, which is an amm config account, it will fail since it still thinks that the account is a tick array state in set A
Therefore, I added a check to see if the account is actually a tick array state, if not, then break the loop