### PR TITLE
fix: swap_v2 base-output DoS for Token-2022 transfer fee tokens

### DIFF
--- a/programs/amm/src/instructions/swap_v2.rs
+++ b/programs/amm/src/instructions/swap_v2.rs
@@ -315,7 +315,9 @@ pub fn exact_internal_v2<'c: 'info, 'info>(
         require_gt!(pool_state.sqrt_price_x64, swap_price_before);
     }
     if sqrt_price_limit_x64 == 0 {
-        // Does't allow partial filled without specified limit_price.
+        // Doesn't allow partial fill without specified limit_price.
+        // For base_output with transfer fee tokens, use amount_calculate_specified
+        // since swap_internal receives the adjusted amount (including transfer fee).
         if is_base_input {
             if zero_for_one {
                 require_eq!(amount_specified, transfer_amount_0);
@@ -324,9 +326,9 @@ pub fn exact_internal_v2<'c: 'info, 'info>(
             }
         } else {
             if zero_for_one {
-                require_eq!(amount_specified, transfer_amount_1);
+                require_eq!(amount_calculate_specified, transfer_amount_1);
             } else {
-                require_eq!(amount_specified, transfer_amount_0);
+                require_eq!(amount_calculate_specified, transfer_amount_0);
             }
         }
     }


### PR DESCRIPTION
## 🚨 HIGH SEVERITY: Permanent DoS in swap_v2 for Token-2022 Transfer Fee Tokens

### Summary
The `swap_v2` instruction's no-partial-fill validation causes **permanent denial of service** for all base-output swaps involving Token-2022 tokens with transfer fees. The bug is a **mathematical certainty** — every transaction will unconditionally revert when `is_base_input = false`, `sqrt_price_limit_x64 = 0`, and the output token has a non-zero transfer fee.

### Root Cause
For base-output swaps, `amount_calculate_specified = amount_specified + transfer_fee` is passed to `swap_internal()`. After the swap, the validation incorrectly compares `amount_specified` (original input) against `transfer_amount` (which equals `amount_calculate_specified`). These can **never be equal** when transfer_fee > 0.

### Impact
- **Complete functionality loss** for affected token pairs in base-output mode
- **All CLMM pools** containing Token-2022 transfer-fee tokens are affected
- **DEX aggregators** (Jupiter, etc.) routing through these pools will see silent failures
- **Growing risk** as Token-2022 adoption accelerates on Solana
- **Requires program upgrade** to fix (immutable on-chain)

### Proof
```
amount_specified = X
transfer_fee = ceil(X * f / (10000 - f))  // always > 0 when f > 0
amount_calculate_specified = X + transfer_fee > X
swap_internal(amount_calculate_specified) → transfer_amount = amount_calculate_specified
require_eq!(X, X + transfer_fee) → ALWAYS REVERTS
```

### Fix
Replace `amount_specified` with `amount_calculate_specified` in the base-output validation path (lines 327, 329). The base-input path is correct and unchanged.

Full audit report: https://github.com/unicornnoway/raydium-clmm/blob/fix/swap-v2-transfer-fee-dos/AUDIT.md